### PR TITLE
fix: don't poll forever for stopped deployments

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -55,7 +55,7 @@ function getActiveDeployments() {
     aws deploy list-deployments \
         --application-name "$INPUT_CODEDEPLOY_NAME" \
         --deployment-group-name "$INPUT_CODEDEPLOY_GROUP" \
-        --include-only-statuses "Queued" "InProgress" "Stopped" |  jq -r '.deployments';
+        --include-only-statuses "Queued" "InProgress" |  jq -r '.deployments';
 }
 
 function pollForActiveDeployments() {


### PR DESCRIPTION
fixes: #12 

A project has a stopped deployment and we are forever finding it and polling until max, so we shouldn't include that. Only builds in progress or queued to go out.