### PR TITLE
build: fix name to align with legal rules

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
-name: 'AWS CodeDeploy'
-description: 'Deploy projects to EC2 via CodeDeploy'
+name: 'Sourcetoad - AWS CodeDeploy for GitHub Actions'
+description: 'Deploy projects to EC2 via CodeDeploy for GitHub Actions'
 author: Sourcetoad
 branding:
   color: 'yellow'


### PR DESCRIPTION
https://aws.amazon.com/trademark-guidelines/