### PR TITLE
build: lock awscli to specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli
+FROM amazon/aws-cli:2.1.29
 
 # Move files in for deployment & cleanup
 COPY deploy.sh /deploy.sh


### PR DESCRIPTION
Using latest prevents GitHub from caching cleanly leading to an extra 21s per build. If we just lock to a version and update when needed - this seems safer from breaking changes and caching.