### PR TITLE
Support for "directory" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Laravel (All Properties) Example
     s3_folder: production
     excluded_files: '.git/* .env storage/framework/cache/* node_modules/*'
     max_polling_iterations: 60
+    directory: ./
 ```
 
 Laravel (Only Required) Example
@@ -52,6 +53,7 @@ Following inputs can be used as `step.with` keys
 | `s3_bucket` | Yes | String | S3 Bucket for archive to be uploaded. |
 | `s3_folder` | Yes | String | S3 Folder for archive to be uploaded within bucket. |
 | `excluded_files` | No | String | Space delimited list of patterns to exclude from archive |
+| `directory` | No | String | Directory to archive. Defaults to root of project. |
 | `max_polling_iterations` | No | Number | Number of 15s iterations to poll max. (default: `60`) |
 
 ## IAM Permissions

--- a/deploy.sh
+++ b/deploy.sh
@@ -58,7 +58,11 @@ echo "$INPUT_EXCLUDED_FILES" | tr ' ' '\n' > "$EXCLUSION_FILE"
 
 echo "::debug::Exclusion file created for files to ignore in Zip Generation."
 
-zip -r --quiet "$ZIP_FILENAME" "$DIR_TO_ZIP" -x "@$EXCLUSION_FILE"
+if [ -n "$DIR_TO_ZIP" ]; then
+    cd "$DIR_TO_ZIP";
+fi
+
+zip -r --quiet "$ZIP_FILENAME" . -x "@$EXCLUSION_FILE"
 if [ ! -f "$ZIP_FILENAME" ]; then
     echo "::error::$ZIP_FILENAME was not generated properly (zip generation failed)."
     exit 1;


### PR DESCRIPTION
So I tried to use "directory" to only code-deploy "build" folder. The zipped folder included that directory and AWS was not happy.

```
Archive:  643330535-56944eaf5db34c5f5b39ab7e20d9bf81cc914548.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  03-11-2021 11:00   build/
       25  03-11-2021 11:00   build/robots.txt
     1150  03-11-2021 11:00   build/favicon.ico
```

Should have been:
```
Archive:  643330535-56944eaf5db34c5f5b39ab7e20d9bf81cc914548.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  03-11-2021 11:00   /
       25  03-11-2021 11:00   robots.txt
     1150  03-11-2021 11:00   favicon.ico
```

fixes: #26 