### PR TITLE
add support for `*.tar` and `*.tar.gz` archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ COPY cleanup.sh /cleanup.sh
 
 # Get tools needed for packaging
 RUN yum update -y \
-  && yum install -y zip unzip jq \
+  && yum install -y zip unzip jq tar gzip \
   && yum clean all

--- a/action.yaml
+++ b/action.yaml
@@ -28,10 +28,6 @@ inputs:
   archive:
     description: 'Zip to be used for deployment, instead of archiving a directory.'
     required: false
-  bundle_type:
-    description: >
-      The type of archive: tar, tgz or zip. By default, the extension will
-      be used to auto-detect this value.
   custom_zip_flags:
     description: 'Custom flags to be passed to zip during archiving.'
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,10 @@ inputs:
   archive:
     description: 'Zip to be used for deployment, instead of archiving a directory.'
     required: false
+  bundle_type:
+    description: >
+      The type of archive: tar, tgz or zip. By default, the extension will
+      be used to auto-detect this value.
   custom_zip_flags:
     description: 'Custom flags to be passed to zip during archiving.'
     required: false

--- a/deploy.sh
+++ b/deploy.sh
@@ -87,6 +87,7 @@ if [ -z "$BUNDLE_TYPE" ]; then
     case "$ZIP_FILENAME" in
         *.tar)
             BUNDLE_TYPE=tar
+            ;;
         *.tar.gz)
             BUNDLE_TYPE=tgz
             ;;

--- a/deploy.sh
+++ b/deploy.sh
@@ -104,7 +104,7 @@ if [ "$BUNDLE_TYPE" == 'zip' ]; then
         exit 1;
     fi
 else
-    if [ "$(tar -tf "$ZIP_FILENAME" | grep -qv appspec.yml)" ]; then
+    if tar -tf "$ZIP_FILENAME" | grep -qv appspec.yml; then
         echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
         exit 1;
     fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -83,7 +83,7 @@ else
 fi
 
 if [ -z "$BUNDLE_TYPE" ]; then
-    # permitted values for BUNDLE_TYPE can be found here: https://docs.aws.amazon.com/codedeploy/latest/userguide/application-revisions-register.html#application-revisions-register-s3
+    # permitted values for BUNDLE_TYPE can be found here: https://docs.aws.amazon.com/codedeploy/latest/userguide/application-revisions-push.html#push-with-cli
     case "$ZIP_FILENAME" in
         *.tar)
             BUNDLE_TYPE=tar

--- a/deploy.sh
+++ b/deploy.sh
@@ -82,10 +82,29 @@ else
     ZIP_FILENAME="$INPUT_ARCHIVE"
 fi
 
+if [ -z "$ARCHIVE_TYPE" ]; then
+    case "$ZIP_FILENAME" in
+        *.tar)
+        *.tar.gz)
+            ARCHIVE_TYPE=tarball
+            ;;
+        *)
+            # assume it's a zipfile
+            ARCHIVE_TYPE=zipfile
+            ;;
+    ecas
+fi
 
-if [ "$(unzip -l "$ZIP_FILENAME" | grep -q appspec.yml)" = "0" ]; then
-    echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
-    exit 1;
+if [ $ARCHIVE_TYPE == 'zipfile' ]; then
+    if [ "$(unzip -l "$ZIP_FILENAME" | grep -q appspec.yml)" = "0" ]; then
+        echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
+        exit 1;
+    fi
+else
+    if [ "$(tar -tf "$ZIP_FILENAME" | grep -qv appspec.yml)" ]; then
+        echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
+        exit 1;
+    fi
 fi
 
 echo "::debug::Zip Archived validated."

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,6 +23,18 @@ if [ -z "$INPUT_S3_BUCKET" ] && [ -z "$INPUT_DRY_RUN" ]; then
     exit 1;
 fi
 
+if [ -z "$INPUT_ARCHIVE" ] && [ -n "$INPUT_BUNDLE_TYPE" ]; then
+    echo '::error::bundle_type requires archive to be provided too'
+fi
+
+if [ -n "$INPUT_BUNDLE_TYPE" ] \
+&& [ "$INPUT_BUNDLE_TYPE" !== 'zip' ] \
+&& [ "$INPUT_BUNDLE_TYPE" !== 'tar' ] \
+&& [ "$INPUT_BUNDLE_TYPE" !== 'tgz' ]; then
+    echo '::error::bundle_type must be one of zip, tar or tgz'
+    exit 1;
+fi
+
 echo "::debug::Input variables correctly validated."
 
 # 0.5) Validation of AWS Creds
@@ -82,6 +94,8 @@ else
     ZIP_FILENAME="$INPUT_ARCHIVE"
 fi
 
+BUNDLE_TYPE="$INPUT_BUNDLE_TYPE"
+
 if [ -z "$BUNDLE_TYPE" ]; then
     # permitted values for BUNDLE_TYPE can be found here: https://docs.aws.amazon.com/codedeploy/latest/userguide/application-revisions-push.html#push-with-cli
     case "$ZIP_FILENAME" in
@@ -98,16 +112,20 @@ if [ -z "$BUNDLE_TYPE" ]; then
     ecas
 fi
 
-if [ $BUNDLE_TYPE == 'zip' ]; then
+if [ "$BUNDLE_TYPE" == 'zip' ]; then
     if [ "$(unzip -l "$ZIP_FILENAME" | grep -q appspec.yml)" = "0" ]; then
         echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
         exit 1;
     fi
-else
+elif [ "$BUNDLE_TYPE" == 'tar' ] || [ "$BUNDLE_TYPE" == 'tgz' ]; then
     if [ "$(tar -tf "$ZIP_FILENAME" | grep -qv appspec.yml)" ]; then
         echo "::error::$ZIP_FILENAME was not generated properly (missing appspec.yml)."
         exit 1;
     fi
+else
+    # this should be unreachable
+    echo '::error::internal errror (unreachable)'
+    exit 1;
 fi
 
 echo "::debug::Zip Archived validated."

--- a/deploy.sh
+++ b/deploy.sh
@@ -109,7 +109,7 @@ if [ -z "$BUNDLE_TYPE" ]; then
             # assume it's a zipfile
             BUNDLE_TYPE=zip
             ;;
-    ecas
+    esac
 fi
 
 if [ "$BUNDLE_TYPE" == 'zip' ]; then


### PR DESCRIPTION
Hi there! Thanks for providing this GitHub action—I really like the colorized output. ✨ 

This PR adds support for archives in `.tar` or `.tar.gz` format.

* usage: `archive: path/to/archive.tar.gz`
* file type is recognised using file extension: `.tar` or `.tar.gz`
* no change to behaviour of `directory`: if specified, it still creates an archive using `zip`