### PR TITLE
add optional codedeploy_config_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Following inputs can be used as `step.with` keys
 | `aws_region`               | No       | String  | AWS Region (default: `us-east-1`).                              |
 | `codedeploy_name`          | Yes      | String  | CodeDeploy Project Name.                                        |
 | `codedeploy_group`         | Yes      | String  | CodeDeploy Project Group.                                       |
+| `codedeploy_config_name`   | No       | String  | If provided, override the default CodeDeploy Configuration name |
 | `codedeploy_register_only` | No       | Boolean | If true, revision is registered not deployed.                   |
 | `s3_bucket`                | Yes      | String  | S3 Bucket for archive to be uploaded.                           |
 | `s3_folder`                | Yes      | String  | S3 Folder for archive to be uploaded within bucket.             |

--- a/action.yaml
+++ b/action.yaml
@@ -40,6 +40,9 @@ inputs:
   codedeploy_group:
     description: 'AWS CodeDeploy Application Group'
     required: true
+  codedeploy_config_name:
+    description: 'Override the AWS CodeDeploy configuration name'
+    required: false
   codedeploy_register_only:
     description: 'Whether to register the deployment (vs automatic deploy).'
     required: false

--- a/deploy.sh
+++ b/deploy.sh
@@ -188,9 +188,15 @@ pollForActiveDeployments
 
 # 5) Poll / Complete
 function deployRevision() {
+    EXTRA_ARGS=''
+    if [ -n "$INPUT_CODEDEPLOY_CONFIG_NAME" ]; then
+        EXTRA_ARGS="--deployment-config-name $INPUT_CODEDEPLOY_CONFIG_NAME"
+    fi
+    
     aws deploy create-deployment \
         --application-name "$INPUT_CODEDEPLOY_NAME" \
         --deployment-group-name "$INPUT_CODEDEPLOY_GROUP" \
+        ${EXTRA_ARGS} \
         --description "$GITHUB_REF - $GITHUB_SHA" \
         --s3-location bucket="$INPUT_S3_BUCKET",bundleType=zip,eTag="$ZIP_ETAG",key="$INPUT_S3_FOLDER"/"$ZIP_FILENAME" | jq -r '.deploymentId'
 }


### PR DESCRIPTION
By default, CodeDeploy uses the deployment config attached to the deployment group, and if that's not set, it uses `CodeDeployDefault.OneAtATime`.

However, there may be some cases where you need to temporarily override the deployment config—for example, during the initial deployment of an application, it's probably best to use `CodeDeployDefault.AllAtOnce`. This PR allows the deployment config to be overridden 

* usage: `codedeploy_config_name: <config-name>`
* example: `codedeploy_config_name: CodeDeployDefault.OneAtATime`
* if not provided, the default behaviour is maintained

Split from #73