### PR TITLE
Fix a logic error in the the check for appspec.yml when using tgz archives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ COPY cleanup.sh /cleanup.sh
 
 # Get tools needed for packaging
 RUN yum update -y \
-  && yum install -y zip unzip jq \
+  && yum install -y zip unzip jq tar gzip \
   && yum clean all


### PR DESCRIPTION
Hi there!

Thanks for merging my previous PR (#73)! Unfortunately, I introduced a logic error in the check for appspec.yml

Currently:
* check for files that do not match appspec.yml
* raise an error if any are found

Unfortunately, there's typically going to be logs of files that aren't named appspec.yml!

This PR fixes the error:
* check for the existence of appspec.yaml, then negate the result

(Thanks @vikasperi for providing the fix!)