### PR TITLE
aws-cli 2.11.11 and no more "yum update"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli:2.11.4
+FROM amazon/aws-cli:2.11.11
 
 # Move files in for deployment & cleanup
 COPY deploy.sh /deploy.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ COPY deploy.sh /deploy.sh
 COPY cleanup.sh /cleanup.sh
 
 # Get tools needed for packaging
-RUN yum update -y \
-  && yum install -y zip unzip jq tar gzip \
-  && yum clean all
+RUN yum install -y zip unzip jq tar gzip && \
+    yum clean all && \
+    rm -rf /var/cache/yum


### PR DESCRIPTION
As we saw in https://github.com/sourcetoad/aws-ecs-deploy-action/pull/5, its slow to run a update prior to installing dependencies.