### PR TITLE
Expose the deployment id

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -60,6 +60,8 @@ outputs:
     description: 'Filename of generated zip file.'
   etag:
     description: 'ETag for the generated zip file reported by AWS.'
+  deployment_id:
+    description: 'The CodeDeploy deployment id'
 runs:
     using: 'docker'
     image: 'Dockerfile'

--- a/deploy.sh
+++ b/deploy.sh
@@ -238,6 +238,8 @@ else
         DEPLOYMENT_ID=$(deployRevision)
     fi
 
+    echo "deployment_id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+
     if [ "$INPUT_MAX_POLLING_ITERATIONS" -eq "0" ]; then
         echo -e "${BLUE}Iterations at 0. GitHub Action ending, but deployment in-progress to: ${RESET_TEXT}$INPUT_CODEDEPLOY_GROUP.";
     else


### PR DESCRIPTION
Update the action to expose the CodeDeploy deployment id to be used in future actions