### PR TITLE
feat: added deploymentOverview check for provisioning wait

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -51,7 +51,7 @@ function pollForSpecificDeployment() {
 
     while true; do
         RESPONSE=$(getSpecificDeployment "$1")
-        FAILED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Failed')
+        FAILED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Failed // "?"')
         IN_PROGRESS_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.InProgress')
         SKIPPED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Skipped')
         SUCCESS_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Succeeded')
@@ -60,7 +60,7 @@ function pollForSpecificDeployment() {
 
         echo -e "${ORANGE}Deployment in progress. Sleeping 15 seconds. (Try $((++deadlockCounter)))";
 
-        if [ "$FAILED_COUNT" == "null" ]; then
+        if [ "$FAILED_COUNT" == "?" ]; then
             echo -e "Instance Overview: ${ORANGE}Currently Provisioning..."
             echo -e "Deployment Status: $STATUS"
         else

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,7 +51,6 @@ function pollForSpecificDeployment() {
 
     while true; do
         RESPONSE=$(getSpecificDeployment "$1")
-        OVERVIEW_CHECK=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview')
         FAILED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Failed')
         IN_PROGRESS_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.InProgress')
         SKIPPED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Skipped')
@@ -61,7 +60,7 @@ function pollForSpecificDeployment() {
 
         echo -e "${ORANGE}Deployment in progress. Sleeping 15 seconds. (Try $((++deadlockCounter)))";
 
-        if [ "$OVERVIEW_CHECK" == "null" ]; then
+        if [ "$FAILED_COUNT" == "null" ]; then
             echo -e "Instance Overview: ${ORANGE}Currently Provisioning..."
             echo -e "Deployment Status: $STATUS"
         else

--- a/deploy.sh
+++ b/deploy.sh
@@ -51,6 +51,7 @@ function pollForSpecificDeployment() {
 
     while true; do
         RESPONSE=$(getSpecificDeployment "$1")
+        OVERVIEW_CHECK=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview')
         FAILED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Failed')
         IN_PROGRESS_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.InProgress')
         SKIPPED_COUNT=$(echo "$RESPONSE" | jq -r '.deploymentInfo.deploymentOverview.Skipped')
@@ -59,12 +60,18 @@ function pollForSpecificDeployment() {
         STATUS=$(echo "$RESPONSE" | jq -r '.deploymentInfo.status')
 
         echo -e "${ORANGE}Deployment in progress. Sleeping 15 seconds. (Try $((++deadlockCounter)))";
-        echo -e "Instance Overview: ${RED}Failed ($FAILED_COUNT), ${BLUE}In-Progress ($IN_PROGRESS_COUNT), ${RESET_TEXT}Skipped ($SKIPPED_COUNT), ${BLUE}Pending ($PENDING_COUNT), ${GREEN}Succeeded ($SUCCESS_COUNT)"
-        echo -e "Deployment Status: $STATUS"
 
-        if [ "$FAILED_COUNT" -gt 0 ]; then
-            echo -e "${RED}Failed instance detected (Failed count over zero)."
-            exit 1;
+        if [ "$OVERVIEW_CHECK" == "null" ]; then
+            echo -e "Instance Overview: ${ORANGE}Currently Provisioning..."
+            echo -e "Deployment Status: $STATUS"
+        else
+            echo -e "Instance Overview: ${RED}Failed ($FAILED_COUNT), ${BLUE}In-Progress ($IN_PROGRESS_COUNT), ${RESET_TEXT}Skipped ($SKIPPED_COUNT), ${BLUE}Pending ($PENDING_COUNT), ${GREEN}Succeeded ($SUCCESS_COUNT)"
+            echo -e "Deployment Status: $STATUS"
+
+            if [ "$FAILED_COUNT" -gt 0 ]; then
+                echo -e "${RED}Failed instance detected (Failed count over zero)."
+                exit 1;
+            fi
         fi
 
         if [ "$STATUS" = "Failed" ]; then
@@ -80,6 +87,7 @@ function pollForSpecificDeployment() {
             echo -e "${RED}Max polling iterations reached (max_polling_iterations)."
             exit 1;
         fi
+
         sleep 15s;
     done;
 }


### PR DESCRIPTION
Issue brought up about an [Error with Blue Green deployment](https://github.com/sourcetoad/aws-codedeploy-action/issues/91) where the deploymentOverview was missing from the JSON while the instances are being provisioned.

Quick solution for now is to avoid triggering an error resulting from a null response for the missing data and to provide a message stating that it is currently provisioning while we wait for the data to be populated.

fixes: #91 