### PR TITLE
Recognize .tgz as tgz BUNDLE_TYPE

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -190,6 +190,9 @@ case "$ZIP_FILENAME" in
     *.tar.gz)
         BUNDLE_TYPE=tgz
         ;;
+    *.tgz)
+        BUNDLE_TYPE=tgz
+        ;;
     *)
         # assume it's a zipfile
         BUNDLE_TYPE=zip

--- a/deploy.sh
+++ b/deploy.sh
@@ -187,10 +187,7 @@ case "$ZIP_FILENAME" in
     *.tar)
         BUNDLE_TYPE=tar
         ;;
-    *.tar.gz)
-        BUNDLE_TYPE=tgz
-        ;;
-    *.tgz)
+    *.tar.gz|*.tgz)
         BUNDLE_TYPE=tgz
         ;;
     *)


### PR DESCRIPTION
Previously, `tgz` files were incorrectly recognized as ZIP.