### PR TITLE
remove exit when failed count is more than 0

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -70,7 +70,7 @@ function pollForSpecificDeployment() {
 
             if [ "$FAILED_COUNT" -gt 0 ]; then
                 echo -e "${RED}Failed instance detected (Failed count over zero)."
-                exit 1;
+                # exit 1;
             fi
         fi
 


### PR DESCRIPTION
Failed instance is resulting in fail of the workflow.

The result of job should not be decided based on the failed count but on the codeDeploy status.

Hence removing the exit when failed instance count is over zero