### PR TITLE
JEST-1937 build: upgrade to aws cli 2.27.50

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazon/aws-cli:2.27.11
+FROM amazon/aws-cli:2.27.50
 
 # Move files in for deployment & cleanup
 COPY deploy.sh /deploy.sh


### PR DESCRIPTION
This pull request primarily focuses on upgrading aws cli to the [Latest](https://hub.docker.com/layers/amazon/aws-cli/2.27.50/images/sha256-d530fdce96a60e6df89cb51b004fb08aa02aaa6810188cb8488bc00a56cc3cdc)